### PR TITLE
minor updates

### DIFF
--- a/_utils/benchmarking_utils.py
+++ b/_utils/benchmarking_utils.py
@@ -136,10 +136,10 @@ def eval_with_w(adj_df,W,do_abs=True,title="[]",weight_threshold=0.3,common=[],W
     y_score = adj_melt['value'].tolist()
 
     # scatterplots with distribution
-    y_true_posi, y_score_posi, overall_score = customized_scatter_plot(y_true, y_score, xlabel, ylabel, title=title, weight_threshold=weight_threshold, do_plot=True)
+    y_true_posi, y_score_posi, overall_score = customized_scatter_plot(y_true, y_score, xlabel, ylabel, title=title, weight_threshold=weight_threshold, do_plot=False)
     local_score = plot_sns_scatter(y_true_posi, y_score_posi, 
                                    xlabel=xlabel,ylabel=ylabel,
-                                   title="",do_plot=do_plot,dpi=DPI)
+                                   title=title,do_plot=do_plot,dpi=DPI)
 
     return adj_melt, w_melt, overall_score, local_score
 

--- a/network_models/my_estimator/core.py
+++ b/network_models/my_estimator/core.py
@@ -407,7 +407,7 @@ class NotearsMLP(nn.Module, BaseEstimator):
 
             # sum the losses across all dist types
             for dist_type in self.dist_types:
-                loss = loss + (self.ls_gamma*dist_type.loss(X, X_hat)) + ((1-self.ls_gamma)*dist_type.adj_loss(W, adj, binary_mask))
+                loss = loss + ((1-self.ls_gamma)*dist_type.loss(X, X_hat)) + (self.ls_gamma*dist_type.adj_loss(W, adj, binary_mask))  # NOTE: 251217 update
 
             lagrange_penalty = 0.5 * rho * h_val * h_val + alpha * h_val
             # NOTE: both the l2 and l1 regularization are NOT applied to the bias parameters


### PR DESCRIPTION
This pull request makes targeted updates to improve the accuracy and clarity of evaluation and loss calculation in the benchmarking and model estimation utilities. The primary changes involve correcting the order of loss weighting in the model and enhancing the plotting logic for evaluation.

Loss calculation logic update:

* In `network_models/my_estimator/core.py`, the weights for the two loss components in the loop over `dist_types` have been swapped, so that `(1 - ls_gamma)` now weights the main loss and `ls_gamma` weights the adjacency loss, correcting the intended balance between these terms.

Evaluation and plotting improvements:

* In `_utils/benchmarking_utils.py`, the call to `customized_scatter_plot` now disables plotting by default, and the subsequent scatter plot uses the correct title, ensuring consistency and clarity in evaluation visualizations.